### PR TITLE
Update OpenyActivityFinderSolrBackend.php

### DIFF
--- a/src/OpenyActivityFinderSolrBackend.php
+++ b/src/OpenyActivityFinderSolrBackend.php
@@ -160,10 +160,10 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
     $query->getParseMode()->setConjunction('OR');
     $query->setParseMode($parse_mode);
     $keys = !empty($parameters['keywords']) ? $parameters['keywords'] : '';
-    if ($keys) {
+    if ($keys != '') {
       $multiple_keys = explode(' ', trim($keys));
       if (count($multiple_keys) >= 2) {
-        $keys['#conjunction'] = 'AND';
+        $multiple_keys['#conjunction'] = 'AND';
         $query->keys($multiple_keys);
       }
       else {

--- a/src/OpenyActivityFinderSolrBackend.php
+++ b/src/OpenyActivityFinderSolrBackend.php
@@ -160,15 +160,8 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
     $query->getParseMode()->setConjunction('OR');
     $query->setParseMode($parse_mode);
     $keys = !empty($parameters['keywords']) ? $parameters['keywords'] : '';
-    if ($keys != '') {
-      $multiple_keys = explode(' ', trim($keys));
-      if (count($multiple_keys) >= 2) {
-        $multiple_keys['#conjunction'] = 'AND';
-        $query->keys($multiple_keys);
-      }
-      else {
-        $query->keys($keys);
-      }
+    if($keys){
+      $query->keys($keys);
     }
     $query->setFulltextFields(['title']);
     $query->addCondition('status', 1);

--- a/src/OpenyActivityFinderSolrBackend.php
+++ b/src/OpenyActivityFinderSolrBackend.php
@@ -161,9 +161,14 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
     $query->setParseMode($parse_mode);
     $keys = !empty($parameters['keywords']) ? $parameters['keywords'] : '';
     if ($keys) {
-      $keys = explode(' ', trim($keys));
-      $keys['#conjunction'] = 'AND';
-      $query->keys($keys);
+      $multiple_keys = explode(' ', trim($keys));
+      if (count($multiple_keys) >= 2) {
+        $keys['#conjunction'] = 'AND';
+        $query->keys($multiple_keys);
+      }
+      else {
+        $query->keys($keys);
+      }
     }
     $query->setFulltextFields(['title']);
     $query->addCondition('status', 1);

--- a/src/OpenyActivityFinderSolrBackend.php
+++ b/src/OpenyActivityFinderSolrBackend.php
@@ -156,13 +156,8 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
     $index_id = $this->config->get('index') ? $this->config->get('index') : 'default';
     $index = Index::load($index_id);
     $query = $index->query();
-    $parse_mode = \Drupal::service('plugin.manager.search_api.parse_mode')->createInstance('direct');
-    $query->getParseMode()->setConjunction('OR');
-    $query->setParseMode($parse_mode);
     $keys = !empty($parameters['keywords']) ? $parameters['keywords'] : '';
     if ($keys) {
-      $keys = explode(' ', trim($keys));
-      $keys['#conjunction'] = 'AND';
       $query->keys($keys);
     }
     $query->setFulltextFields(['title']);


### PR DESCRIPTION
On a new Search API Solr infrastructure 4.x version doesn't work, because there is a difference in search_api_solr how keys being handled
Activity Finder v4 will be in OpenY only in Drupal 9 - so it is safe to do this change

Check ( deployed this fix )
https://sandbox-rose-cus-d9.openy.org/activity-finder-v4?step=results&searchKeywords=Before%20and%20After
https://sandbox-rose-cus-d9.openy.org/activity-finder-v4?step=results&searchKeywords=Before

And non-working ( original AF4)
https://sandbox-carnation-cus-d9.openy.org/activity-finder-v4?step=results&searchKeywords=Before