### PR TITLE
AF4: Add weeks parameter into cache ID calculation (used by Camp Finder)

### DIFF
--- a/src/Controller/ActivityFinderController.php
+++ b/src/Controller/ActivityFinderController.php
@@ -76,6 +76,7 @@ class ActivityFinderController extends ControllerBase {
       'day' => $request->get('days'),
       'times' => $request->get('times'),
       'daystimes' => $request->get('daystimes'),
+      'weeks' => $request->get('weeks'),
       'age' => $request->get('ages'),
       'sort' => $request->get('sort'),
     ];


### PR DESCRIPTION
Backport of https://github.com/ymcatwincities/openy_activity_finder/pull/17