### PR TITLE
Filter out excluded activities in Activities filter.

### DIFF
--- a/openy_af4_vue_app/src/App.vue
+++ b/openy_af4_vue_app/src/App.vue
@@ -42,6 +42,7 @@
           :legacy-mode="legacyMode"
           :filters-section-config="filtersSectionConfig"
           :daxko="daxko"
+          :exclude-by-category="excludeByCategory"
           @filterChange="onFilterChange($event, hideModal)"
           @clearFilters="clearFilters(hideModal)"
         />
@@ -161,6 +162,7 @@
           :legacy-mode="legacyMode"
           :filters-section-config="filtersSectionConfig"
           :daxko="daxko"
+          :exclude-by-category="excludeByCategory"
           filters-mode="instant"
           @filterChange="onFilterChange($event)"
           @clearFilters="clearFilters"

--- a/openy_af4_vue_app/src/components/filters/Activities.vue
+++ b/openy_af4_vue_app/src/components/filters/Activities.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="activities-filter-component">
     <Foldable
-      v-for="(item_type, index) in activities"
+      v-for="(item_type, index) in filteredActivities"
       :key="id + '-activity-type-' + index"
       :label="item_type.label"
       :collapse-id="id + '-toggle-' + index"
@@ -55,11 +55,44 @@ export default {
     multiple: {
       type: Boolean,
       default: true
+    },
+    excludeByCategory: {
+      type: Array,
+      required: true
     }
   },
   data() {
     return {
       selectedActivities: this.multiple ? this.value : this.value.length ? this.value[0] : null
+    }
+  },
+  computed: {
+    filteredActivities() {
+      if (!this.excludeByCategory.length) {
+        return this.activities
+      }
+
+      const filteredActivities = {}
+      this.activities.forEach((activityGroup, key) => {
+        // Filter out excluded categories.
+        if (!this.excludeByCategory.length) {
+          filteredActivities[key] = activityGroup
+          return
+        }
+
+        const filteredValue = activityGroup.value.filter(item => {
+          return !this.excludeByCategory.includes(item.value.toString())
+        })
+        if (!filteredValue.length) {
+          return
+        }
+
+        filteredActivities[key] = {
+          ...activityGroup,
+          value: filteredValue
+        }
+      })
+      return filteredActivities
     }
   },
   watch: {

--- a/openy_af4_vue_app/src/components/filters/Filters.vue
+++ b/openy_af4_vue_app/src/components/filters/Filters.vue
@@ -52,6 +52,7 @@
           :activities="activities"
           :facets="data.facets.field_activity_category"
           :multiple="!daxko"
+          :exclude-by-category="excludeByCategory"
         />
       </Fieldset>
 
@@ -170,6 +171,10 @@ export default {
     daxko: {
       type: Boolean,
       default: false
+    },
+    excludeByCategory: {
+      type: Array,
+      required: true
     }
   },
   data() {


### PR DESCRIPTION
This one is a continuation of #40 - this time in the Activities filter on the results page.
The thing is the excluded categories are still showing up in the Activities filter.

Before:
![image](https://user-images.githubusercontent.com/2128648/108455859-fd524980-72a9-11eb-8dcf-b0a327e2c6e6.png)
After:
![image](https://user-images.githubusercontent.com/2128648/108455997-44403f00-72aa-11eb-88ff-22a9619ba90d.png)
