### PR TITLE
fixed a notice message: "Notice: Undefined index: background_image"

### DIFF
--- a/src/Plugin/Block/ActivityFinder4Block.php
+++ b/src/Plugin/Block/ActivityFinder4Block.php
@@ -87,6 +87,7 @@ class ActivityFinder4Block extends BlockBase implements ContainerFactoryPluginIn
       'legacy_mode' => 0,
       'weeks_filter' => 0,
       'hide_home_branch_block' => 0,
+      'background_image' => NULL,
     ];
   }
 


### PR DESCRIPTION
This PR should fix notice:
`Notice: Undefined index: background_image in Drupal\openy_activity_finder\Plugin\Block\ActivityFinder4Block->blockForm() (line 266 of modules/contrib/openy_activity_finder/src/Plugin/Block/ActivityFinder4Block.php).`