### PR TITLE
[AF4] Change npm commands to standard names.

### DIFF
--- a/openy_af4_vue_app.md
+++ b/openy_af4_vue_app.md
@@ -1,23 +1,17 @@
 # README
 
-## Vue CLI
-
-Installation `npm install -g @vue/cli`
-
-Check version `vue --version` =&gt; @vue/cli 4.0.5
-
 ## Library build
 
 Always build in production mode before committing changes.
 
 Production mode:
 ```shell script
-npm run library
+npm run build
 ```
 
 Development mode - watching for changes:
 ```shell script
-npm run library-watch
+npm run dev
 ```
 
 ## Committing code
@@ -25,9 +19,5 @@ npm run library-watch
 Always apply linting rules and build in production mode before committing changes.
 ```shell script
 npm run lint
-npm run library
+npm run build
 ````
-
-## Customize configuration
-
-See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/openy_af4_vue_app/package.json
+++ b/openy_af4_vue_app/package.json
@@ -3,11 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint",
-    "library": "vue-cli-service build --target lib --formats umd-min --name activity_finder_4 src/main.js",
-    "library-watch": "vue-cli-service build --target lib --formats umd-min --name activity_finder_4 src/main.js --watch"
+    "build": "vue-cli-service build --target lib --formats umd-min --name activity_finder_4 src/main.js",
+    "dev": "vue-cli-service build --target lib --formats umd-min --name activity_finder_4 src/main.js --watch",
+    "lint": "vue-cli-service lint"
   },
   "dependencies": {
     "axios": "^0.21.1",


### PR DESCRIPTION
Change used npm commands to standard build / dev ones. We didn't make any use of removed build / serve commands and having the custom `npm run library` command is unusual and doesn't add any value.