### PR TITLE
Sidebar single filter issue.

### DIFF
--- a/js/programs_search.js
+++ b/js/programs_search.js
@@ -278,7 +278,7 @@
 
   // Does not yet support flat list of radios. Only two level as for Daxko location.
   Vue.component('sidebar-filter-single', {
-    props: ['title', 'id', 'options', 'default', 'type', 'hide_label', 'expander_sections_config', 'loading'],
+    props: ['title', 'id', 'options', 'default', 'type', 'expanded', 'hide_label', 'expander_sections_config', 'loading'],
     data: function() {
       return {
         radios: [],


### PR DESCRIPTION
Resolves [openy_activity_finder#68](https://github.com/ymcatwincities/openy_activity_finder/issues/68)

**Test Steps:**
- Please pull the code.
- Clear the caches after the code is merged
- This should fix the issue. Please check on the front end the filters should now appear.