### PR TITLE
feat: Do not collapse locations and activities options if there is only one group.

### DIFF
--- a/openy_af4_vue_app/src/components/steps/SelectActivities.vue
+++ b/openy_af4_vue_app/src/components/steps/SelectActivities.vue
@@ -18,6 +18,7 @@
           :counter="subFiltersCount(index)"
           :counter-options="optionsCount(index)"
           accordion="accordion-activities"
+          :collapsible="Object.keys(filteredActivities).length !== 1"
           :handle-sticky="handleSticky"
         >
           <div class="options">

--- a/openy_af4_vue_app/src/components/steps/SelectLocations.vue
+++ b/openy_af4_vue_app/src/components/steps/SelectLocations.vue
@@ -18,7 +18,7 @@
           :counter="subFiltersCount(index)"
           :counter-options="optionsCount(index)"
           accordion="accordion-locations"
-          :collapsed="true"
+          :collapsible="Object.keys(filteredLocations).length !== 1"
           :handle-sticky="handleSticky"
         >
           <div class="options">


### PR DESCRIPTION
When you go through the Activity Finder wizard there are 2 steps with locations and activities. They are grouped into several collapsible fieldsets - and there are cases when you have just one group of options - then it doesn't make sense to make this group collapsible and it is better to show all the options right away.

Examples: https://ymcagbw.org/ymca-summer-camp-finder?step=selectLocations
![image](https://user-images.githubusercontent.com/2128648/154011506-f686561c-0585-4a7c-b6f9-bde6f797e764.png)
https://ymcagbw.org/ymca-summer-camp-finder?step=selectActivities
![image](https://user-images.githubusercontent.com/2128648/154011573-8b3a5bf0-3d4d-4ca0-8c62-ccb8295a9206.png)
https://ymcagbw.org/ymca-activity-finder?step=selectLocations
![image](https://user-images.githubusercontent.com/2128648/154011716-25308a96-4324-4ff2-8cef-43151d2f8d5a.png)

NB: requires artifacts rebuild.