### PR TITLE
Handle zero availability case

### DIFF
--- a/src/OpenyActivityFinderSolrBackend.php
+++ b/src/OpenyActivityFinderSolrBackend.php
@@ -450,7 +450,7 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
         'location_name' => '',
         'location_address' => '',
         'location_phone' => '',
-        'spots_available' => $entity->field_availability->value ?? '',
+        'spots_available' => !$entity->field_availability->isEmpty() ? $entity->field_availability->value : '',
         'status' => $availability_status,
         'note' => $availability_note,
         'learn_more' => !empty($learn_more) ? $learn_more : '',

--- a/src/OpenyActivityFinderSolrBackend.php
+++ b/src/OpenyActivityFinderSolrBackend.php
@@ -450,7 +450,7 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
         'location_name' => '',
         'location_address' => '',
         'location_phone' => '',
-        'spots_available' => !$entity->field_availability->isEmpty() ? $entity->field_availability->value : '',
+        'spots_available' => $entity->field_availability->value ?? '',
         'status' => $availability_status,
         'note' => $availability_note,
         'learn_more' => !empty($learn_more) ? $learn_more : '',

--- a/templates/openy-activity-finder-program-search-page.html.twig
+++ b/templates/openy-activity-finder-program-search-page.html.twig
@@ -284,17 +284,15 @@
                     <div v-html="item.price" class="item-price"></div>
                     {% if not is_spots_available_disabled %}
                     <div class="availability-wrapper">
-                      {# if we know that registration is available #}
-                      <div v-if="item.availability_status == 'open'">
-                        <div v-if="item.spots_available >=1" v-bind:class="[item.spots_available <= 3 ? item.spots_available == 1 ? 'few-spots only-one' : 'few-spots' : '', 'spots-availability']">
-                          ${ item.spots_available }
+                      {# if we know that registration is available AND spots are open #}
+                      <div v-if="item.availability_status == 'open' && item.spots_available > 0">
+                        <div v-if="item.spots_available" v-bind:class="[item.spots_available <= 3 ? item.spots_available == 1 ? 'few-spots only-one' : 'few-spots' : '', 'spots-availability']">${ item.spots_available }
                           <span v-if="item.spots_available == 1">spot</span>
                           <span v-if="item.spots_available > 1">spots</span>
-                          left
-                        </div>
+                          left</div>
                       </div>
-                      {# if we know that registration is NOT available #}
-                      <div v-if="item.availability_status == 'closed'">
+                      {# if we know that registration is NOT available OR no spots are available #}
+                      <div v-if="item.availability_status == 'closed' || item.spots_available === '0'">
                         <span class="spots-availability">{{ 'FULL'|t }}</span>
                       </div>
                     </div>
@@ -398,6 +396,9 @@
                           <span v-if="moreInfoPopup.spots_available == 1">spot</span>
                           <span v-if="moreInfoPopup.spots_available > 1">spots</span>
                           left
+                        </div>
+                        <div v-if="moreInfoPopup.spots_available === '0'">
+                          <span class="spots-availability">{{ 'FULL'|t }}</span>
                         </div>
                       {% endif %}
                       <div v-if="moreInfoPopup.activity_type == 'group'" class="availability_status activity_type">

--- a/templates/openy-activity-finder-program-search-page.html.twig
+++ b/templates/openy-activity-finder-program-search-page.html.twig
@@ -286,10 +286,12 @@
                     <div class="availability-wrapper">
                       {# if we know that registration is available AND spots are open #}
                       <div v-if="item.availability_status == 'open' && item.spots_available > 0">
-                        <div v-if="item.spots_available" v-bind:class="[item.spots_available <= 3 ? item.spots_available == 1 ? 'few-spots only-one' : 'few-spots' : '', 'spots-availability']">${ item.spots_available }
+                        <div v-if="item.spots_available >=1" v-bind:class="[item.spots_available <= 3 ? item.spots_available == 1 ? 'few-spots only-one' : 'few-spots' : '', 'spots-availability']">
+                          ${ item.spots_available }
                           <span v-if="item.spots_available == 1">spot</span>
                           <span v-if="item.spots_available > 1">spots</span>
-                          left</div>
+                          left
+                        </div>
                       </div>
                       {# if we know that registration is NOT available OR no spots are available #}
                       <div v-if="item.availability_status == 'closed' || item.spots_available === '0'">


### PR DESCRIPTION
Activities may have zero spots available but still have signups open (if they have a wait list).

I needed to:
- pass the `0` to the front-end instead of `''`
- have the front-end handle the zero value like "full"

Fixes #150 

To test:
- Set the `spots available` field on a session to `0`
- Observe that the front-end displays `FULL`