### PR TITLE
Make logs configurable

### DIFF
--- a/config/install/openy_activity_finder.settings.yml
+++ b/config/install/openy_activity_finder.settings.yml
@@ -12,5 +12,5 @@ hb_modal_text2: "The options you've selected do not match any activities availab
 hb_modal_text3: "Please select one of the options below to proceed:"
 hb_modal_text4: "View available locations"
 hb_modal_text5: "Adjust my filters"
-disable_program_search_log: 0
-disable_cache_debug_log: 0
+disable_program_search_log: 1
+disable_cache_debug_log: 1

--- a/config/install/openy_activity_finder.settings.yml
+++ b/config/install/openy_activity_finder.settings.yml
@@ -12,3 +12,5 @@ hb_modal_text2: "The options you've selected do not match any activities availab
 hb_modal_text3: "Please select one of the options below to proceed:"
 hb_modal_text4: "View available locations"
 hb_modal_text5: "Adjust my filters"
+disable_program_search_log: 0
+disable_cache_debug_log: 0

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -287,6 +287,22 @@ class SettingsForm extends ConfigFormBase {
       '#description' => $this->t('Check this if you want default state for whole this group is "Collapsed"'),
     ];
 
+    $form['logging'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Logging settings'),
+      '#open' => TRUE,
+    ];
+    $form['logging']['disable_program_search_log'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Disable program search log.'),
+      '#default_value' => $config->get('disable_program_search_log') ?? FALSE,
+    ];
+    $form['logging']['disable_cache_debug_log'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Disable cache debug log.'),
+      '#default_value' => $config->get('disable_cache_debug_log') ?? FALSE,
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -313,6 +329,8 @@ class SettingsForm extends ConfigFormBase {
     $config->set('schedule_collapse_group', $form_state->getValue('schedule_collapse_group'))->save();
     $config->set('category_collapse_group', $form_state->getValue('category_collapse_group'))->save();
     $config->set('locations_collapse_group', $form_state->getValue('locations_collapse_group'))->save();
+    $config->set('disable_program_search_log', $form_state->getValue('disable_program_search_log'))->save();
+    $config->set('disable_cache_debug_log', $form_state->getValue('disable_cache_debug_log'))->save();
     $this->cache->deleteAll();
 
     parent::submitForm($form, $form_state);


### PR DESCRIPTION
Added option to disable "Program search" and "Cache debug" logs. Both logs are still enabled bu default and could be disabled in Activity Finder settings form.