### PR TITLE
PHP 8.1: Deprecated function: preg_match()

### DIFF
--- a/src/Plugin/search_api/processor/Week.php
+++ b/src/Plugin/search_api/processor/Week.php
@@ -51,8 +51,10 @@ class Week extends ProcessorPluginBase {
     $object = $item->getOriginalObject();
     $entity = $object->getValue();
 
+    $session_room_value = $entity->field_session_room->value ?? '';
+
     preg_match('/Camp/', $entity->getTitle(), $matches_title);
-    preg_match('/Camp/', $entity->field_session_room->value, $matches_room);
+    preg_match('/Camp/', $session_room_value, $matches_room);
     if ((!empty($matches_title[0]) || !empty($matches_room[0])) && $entity->field_session_time) {
       $dates = $entity->field_session_time->referencedEntities();
       foreach ($dates as $date) {


### PR DESCRIPTION
After updating php to 8.1 the following error has appeared:

`Deprecated function: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in Drupal\openy_activity_finder\Plugin\search_api\processor\Week->addFieldValues() (line 55 of /var/www/docroot/modules/contrib/openy_activity_finder/src/Plugin/search_api/processor/Week.php)`

This PR aims to fix it