### PR TITLE
Resolve php 8.1 deprecation

### DIFF
--- a/src/OpenyActivityFinderSolrBackend.php
+++ b/src/OpenyActivityFinderSolrBackend.php
@@ -242,10 +242,13 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
 
     // Limit categories.
     $limit_nids = [];
+    $limit_nids_config = [];
     if (!empty($parameters['limit'])) {
       $limit_nids = explode(',', $parameters['limit']);
     }
-    $limit_nids_config = explode(',', $this->config->get('limit'));
+    if (!empty($this->config->get('limit'))) {
+      $limit_nids_config = explode(',', $this->config->get('limit'));
+    }
     $limit_nids = array_merge($limit_nids, $limit_nids_config);
     $limit_categories = [];
     foreach ($limit_nids as $nid) {


### PR DESCRIPTION
Deprecated function: explode(): Passing null to parameter #2 ($string) of type string is deprecated in Drupal\openy_activity_finder\OpenyActivityFinderSolrBackend->doSearchRequest() (line 248 of /var/www/html/docroot/modules/contrib/openy_activity_finder/src/OpenyActivityFinderSolrBackend.php)