### PR TITLE
fix: usort: Returning bool from comparison function is deprecated

### DIFF
--- a/src/Plugin/Block/ActivityFinder4Block.php
+++ b/src/Plugin/Block/ActivityFinder4Block.php
@@ -145,11 +145,11 @@ class ActivityFinder4Block extends BlockBase implements ContainerFactoryPluginIn
 
     // Sort activity groups and activities in alphabetical order.
     usort($activities, function ($a, $b) {
-      return $a['label'] > $b['label'];
+      return $a['label'] <=> $b['label'];
     });
     foreach ($activities as &$activity) {
       usort($activity['value'], function ($a, $b) {
-        return $a['label'] > $b['label'];
+        return $a['label'] <=> $b['label'];
       });
     }
 


### PR DESCRIPTION
Ran into this with AF4

> Deprecated function: usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero in Drupal\openy_activity_finder\Plugin\Block\ActivityFinder4Block->build() (line 151 of /var/www/docroot/modules/contrib/openy_activity_finder/src/Plugin/Block/ActivityFinder4Block.php)

Fix as suggested by https://stackoverflow.com/a/65383660/2566038